### PR TITLE
feat: change projects theme from purple to green

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -113,7 +113,7 @@ export default function AccountSettings() {
       <div className="min-h-screen bg-white dark:bg-slate-900 pt-20">
         <div className="container mx-auto px-6 py-12">
           <div className="flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
           </div>
         </div>
       </div>
@@ -266,7 +266,7 @@ export default function AccountSettings() {
 
                 {loadingGithub ? (
                   <div className="flex items-center justify-center py-8">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-purple-600"></div>
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600"></div>
                   </div>
                 ) : githubConnected ? (
                   <div className="space-y-4">
@@ -397,7 +397,7 @@ export default function AccountSettings() {
                 
                 {loadingProjects ? (
                   <div className="flex items-center justify-center py-8">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-purple-600"></div>
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600"></div>
                   </div>
                 ) : projects.length > 0 ? (
                   <div className="space-y-4">

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -104,7 +104,7 @@ export default function AcceptInvitationPage({
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-purple-50 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
       </div>
     );
   }

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -173,7 +173,7 @@ export default function OrganizationSettings() {
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-purple-50 dark:from-slate-900 dark:to-slate-800 py-12">
         <div className="container mx-auto px-6">
           <div className="flex items-center justify-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
           </div>
         </div>
       </div>
@@ -333,7 +333,7 @@ export default function OrganizationSettings() {
             
             {memberLoading ? (
               <div className="flex items-center justify-center py-8">
-                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-purple-600"></div>
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600"></div>
               </div>
             ) : members.length > 0 ? (
               <div className="space-y-3">

--- a/src/app/projects/[id]/board/page.tsx
+++ b/src/app/projects/[id]/board/page.tsx
@@ -889,7 +889,7 @@ ${card.description ? card.description + '\n\n' : ''}${card.acceptanceCriteria ? 
   if (loading) {
     return (
       <div className="h-[calc(100vh-80px)] flex items-center justify-center bg-gray-50 dark:bg-gray-900 pt-20">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     );
   }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -225,7 +225,7 @@ function ProjectsContent() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     );
   }
@@ -272,7 +272,7 @@ function ProjectsContent() {
             <button
               onClick={openCreateModal}
               disabled={usageStatus?.isAtProjectLimit}
-              className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+              className="flex items-center gap-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
             >
               <Plus className="h-5 w-5" />
               New Project
@@ -293,7 +293,7 @@ function ProjectsContent() {
               <button
                 onClick={openCreateModal}
                 disabled={usageStatus?.isAtProjectLimit}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 text-white rounded-lg hover:bg-purple-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
+                className="inline-flex items-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed"
               >
                 <Plus className="h-5 w-5" />
                 New Project
@@ -309,7 +309,7 @@ function ProjectsContent() {
                 className="bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer p-6"
               >
                 <div className="flex items-start justify-between mb-4">
-                  <Folder className="h-8 w-8 text-purple-600" />
+                  <Folder className="h-8 w-8 text-green-600" />
                   <span className="text-sm text-gray-500 dark:text-gray-400">
                     {project._count?.cards || 0} issues
                   </span>
@@ -341,10 +341,10 @@ function ProjectsContent() {
             <div className="space-y-4">
               <button
                 onClick={() => setCreationMode('vibes')}
-                className="w-full p-4 border-2 border-gray-300 dark:border-gray-600 rounded-lg hover:border-purple-500 dark:hover:border-purple-400 transition-colors text-left"
+                className="w-full p-4 border-2 border-gray-300 dark:border-gray-600 rounded-lg hover:border-green-500 dark:hover:border-green-400 transition-colors text-left"
               >
                 <div className="flex items-start gap-3">
-                  <Zap className="h-6 w-6 text-purple-600 mt-1" />
+                  <Zap className="h-6 w-6 text-green-600 mt-1" />
                   <div>
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
                       New alvsys Project
@@ -358,7 +358,7 @@ function ProjectsContent() {
 
               <button
                 onClick={() => setShowGitHubModal(true)}
-                className="w-full p-4 border-2 border-gray-300 dark:border-gray-600 rounded-lg hover:border-purple-500 dark:hover:border-purple-400 transition-colors text-left"
+                className="w-full p-4 border-2 border-gray-300 dark:border-gray-600 rounded-lg hover:border-green-500 dark:hover:border-green-400 transition-colors text-left"
               >
                 <div className="flex items-start gap-3">
                   <Github className="h-6 w-6 text-gray-700 dark:text-gray-300 mt-1" />
@@ -520,7 +520,7 @@ export default function ProjectsPage() {
   return (
     <Suspense fallback={
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600"></div>
       </div>
     }>
       <ProjectsContent />

--- a/src/components/GitHubRepositorySelector.tsx
+++ b/src/components/GitHubRepositorySelector.tsx
@@ -106,7 +106,7 @@ export default function GitHubRepositorySelector({
   if (loadingInstallations) {
     return (
       <div className="p-6 text-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600 mx-auto mb-4"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600 mx-auto mb-4"></div>
         <p className="text-gray-600 dark:text-gray-400">Loading GitHub repositories...</p>
       </div>
     );

--- a/src/components/InlineLabelEditor.tsx
+++ b/src/components/InlineLabelEditor.tsx
@@ -131,7 +131,7 @@ export default function InlineLabelEditor({
                 >
                   <div className="flex items-center justify-center w-4 h-4 border border-gray-300 dark:border-gray-600 rounded">
                     {isUpdating === label.id ? (
-                      <div className="w-3 h-3 border-2 border-purple-600 border-t-transparent rounded-full animate-spin" />
+                      <div className="w-3 h-3 border-2 border-green-600 border-t-transparent rounded-full animate-spin" />
                     ) : selectedLabelIds.includes(label.id) ? (
                       <Check className="h-3 w-3 text-blue-600" />
                     ) : null}

--- a/src/components/McpApiKeyManager.tsx
+++ b/src/components/McpApiKeyManager.tsx
@@ -114,7 +114,7 @@ export default function McpApiKeyManager() {
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600"></div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Update projects page buttons and icons to use green theme
- Change all loading spinners from purple to green
- Update GitHubRepositorySelector, board page, and component spinners
- Maintain consistency across app with green accent colors

## Test plan
- [ ] Navigate to /projects and verify green theme
- [ ] Check loading spinners show green color
- [ ] Test project creation flow styling
- [ ] Verify consistency with marketing page colors

Closes #549

🤖 Generated with [Claude Code](https://claude.ai/code)