### PR TITLE
fix: improve edit issue modal UX - close immediately, then update in …

### DIFF
--- a/src/app/api/find-saas-ideas/scrape/route.ts
+++ b/src/app/api/find-saas-ideas/scrape/route.ts
@@ -14,7 +14,7 @@ interface ScrapedContent {
   author?: string;
   title?: string;
   content: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 
 async function filterComplaints(posts: ScrapedContent[]): Promise<string[]> {
@@ -205,7 +205,7 @@ export async function POST(request: NextRequest) {
 
     // Filter posts to only keep actual complaints using OpenAI
     console.log(`Filtering ${allComplaints.length} posts through OpenAI...`);
-    let complaintUrls: string[] = [];
+    const complaintUrls: string[] = [];
     
     // Process in batches of 20 to stay within token limits
     for (let i = 0; i < allComplaints.length; i += 20) {

--- a/src/app/projects/[id]/board/page.tsx
+++ b/src/app/projects/[id]/board/page.tsx
@@ -324,9 +324,12 @@ export default function ProjectBoardPage({ params }: { params: Promise<{ id: str
     e.preventDefault();
     if (!selectedCard) return;
     
+    // Close modal immediately for better UX
+    closeDetailModal();
+    
+    // Update in background
     try {
       await updateCard(selectedCard, selectedCardLabelIds, selectedCardAssigneeId);
-      closeDetailModal();
     } catch (error) {
       console.error('Error updating card:', error);
     }
@@ -343,16 +346,6 @@ export default function ProjectBoardPage({ params }: { params: Promise<{ id: str
     }, 300);
   }, [resetComments]);
 
-  const saveAndCloseModal = useCallback(async () => {
-    if (!selectedCard) return;
-    
-    try {
-      await updateCard(selectedCard, selectedCardLabelIds, selectedCardAssigneeId);
-      closeDetailModal();
-    } catch (error) {
-      console.error('Error updating card:', error);
-    }
-  }, [selectedCard, selectedCardLabelIds, selectedCardAssigneeId, updateCard, closeDetailModal]);
 
   // Handle escape key and close modal
   useEffect(() => {
@@ -362,7 +355,7 @@ export default function ProjectBoardPage({ params }: { params: Promise<{ id: str
           setModalVisible(false);
           setTimeout(() => setShowCreateModal(false), 300);
         } else if (showDetailModal) {
-          saveAndCloseModal();
+          closeDetailModal();
         }
       }
     };
@@ -387,7 +380,7 @@ export default function ProjectBoardPage({ params }: { params: Promise<{ id: str
         boardElement.style.overflowX = 'auto';
       }
     };
-  }, [showCreateModal, showDetailModal, showSprintModal, showMCPGuideModal, saveAndCloseModal]);
+  }, [showCreateModal, showDetailModal, showSprintModal, showMCPGuideModal, closeDetailModal]);
 
 
   const handleAddComment = async (e: React.FormEvent) => {
@@ -1020,7 +1013,7 @@ ${card.description ? card.description + '\n\n' : ''}${card.acceptanceCriteria ? 
         currentUserId={currentUserId}
         sprints={sprints}
         statusColumns={statusColumns}
-        onClose={saveAndCloseModal}
+        onClose={closeDetailModal}
         onUpdate={handleUpdateCard}
         onAddComment={handleAddComment}
         onCreateLabel={handleCreateLabel}


### PR DESCRIPTION
…background

- Modified handleUpdateCard() to close modal first, then save
- Changed modal onClose prop to closeDetailModal (close without saving)
- Updated escape key handler to close without saving
- Fixed TypeScript errors and removed unused saveAndCloseModal function

This makes clicking outside/X/Cancel close instantly while Update button closes then saves in background for better perceived performance.

🤖 Generated with [Claude Code](https://claude.ai/code)